### PR TITLE
Add API docstrings and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,37 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jqfeld.github.io/ExoMol.jl/dev/)
 [![Build Status](https://github.com/jqfeld/ExoMol.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jqfeld/ExoMol.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/jqfeld/ExoMol.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/jqfeld/ExoMol.jl)
+
+Utilities for downloading and parsing [ExoMol](https://www.exomol.com/) line
+lists directly from Julia. The package wraps the official catalogue,
+transitions and state files in convenient Julia types for further analysis or
+visualisation.
+
+## Installation
+
+Install the package from the Julia package manager:
+
+```julia-repl
+julia> import Pkg
+julia> Pkg.add("ExoMol")
+```
+
+## Quick start
+
+Fetch the ExoMol master catalogue and load a specific isotopologue dataset:
+
+```julia
+using ExoMol
+
+# Inspect the ExoMol master catalogue
+master = get_exomol_master()
+println("There are $(length(master["molecules"])) molecules available.")
+
+# Download and load a molecule/isotopologue/dataset triple
+iso = load_isotopologue("H2O", "1H2-16O", "POKAZATEL")
+
+println("Loaded $(length(iso.states)) states and $(length(iso.transitions)) transitions")
+```
+
+See the [documentation](https://jqfeld.github.io/ExoMol.jl/dev/) for a complete
+API reference and additional usage examples.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,30 @@ CurrentModule = ExoMol
 
 # ExoMol
 
-Documentation for [ExoMol](https://github.com/jqfeld/ExoMol.jl).
+`ExoMol.jl` provides convenience wrappers for downloading ExoMol line lists and
+turning them into Julia-friendly structures.  It handles fetching datasets as
+artifacts, parsing the associated definition files and reading the compressed
+state and transition catalogues.
+
+## Getting started
+
+```julia
+using ExoMol
+
+# Retrieve the master catalogue that lists all available molecules
+master = get_exomol_master()
+
+# Load a dataset and inspect its contents
+iso = load_isotopologue("CO", "12C-16O", "Li2015")
+@info "Loaded $(length(iso.states)) states" first(iso.states)
+@info "Loaded $(length(iso.transitions)) transitions"
+```
+
+The [`Isotopologue`](@ref) struct bundles the dataset definition, states and
+transitions.  See the API reference below for detailed descriptions of the
+helper functions involved in constructing it.
+
+## Reference
 
 ```@index
 ```

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -1,6 +1,18 @@
 using JSON
 
 
+"""
+    read_def_file(filename)
+
+Parse an ExoMol dataset definition (`.def.json`) file.
+
+# Arguments
+- `filename::AbstractString`: Path to the definition file.  Compressed files are
+  not supported and the filename must end in `.json`.
+
+# Returns
+- `Dict{String,Any}`: Parsed JSON data structure describing the dataset.
+"""
 function read_def_file(filename;)
   if endswith(filename, ".json")
     return JSON.parsefile(filename)

--- a/src/download_database.jl
+++ b/src/download_database.jl
@@ -2,6 +2,21 @@ using Pkg.Artifacts
 using JSON
 
 
+"""
+    get_exomol_master_file(; force=false)
+
+Download the ExoMol master catalogue as an artifact and return its local path.
+
+# Arguments
+- `force::Bool=false`: Re-download the catalogue even if it already exists in the
+  artifact cache.
+
+# Returns
+- `String`: Absolute path to the downloaded `exomol.all.json` file.
+
+This function is primarily intended to be used internally.  For direct access to
+the parsed catalogue use [`get_exomol_master`](@ref).
+"""
 function get_exomol_master_file(; force=false)
   artifact_toml = joinpath(pkgdir(@__MODULE__), "Artifacts.toml")
 
@@ -62,6 +77,18 @@ end
 
 
 
+"""
+    get_exomol_master(; force=false)
+
+Retrieve the ExoMol master catalogue as a parsed JSON object.
+
+# Arguments
+- `force::Bool=false`: Re-download the catalogue even if it already exists in the
+  artifact cache.
+
+# Returns
+- `Dict{String,Any}`: Parsed contents of the ExoMol master catalogue.
+"""
 function get_exomol_master(; force=false)
   parse_exomol_master(get_exomol_master_file(; force))
 end

--- a/src/download_dataset.jl
+++ b/src/download_dataset.jl
@@ -5,33 +5,25 @@ using Downloads
 
 
 """
-    get_exomol_dataset(molecule::String, isotopologue::String, dataset::String; 
-                           force::Bool=false, cache_dir::Union{String,Nothing}=nothing)
+    get_exomol_dataset(molecule, isotopologue, dataset; force=false, verbose=false)
 
-Download a specific ExoMol dataset definition file as an artifact.
+Download a specific ExoMol dataset and cache it as an artifact.
 
 # Arguments
-- `molecule::String`: Molecule formula (e.g., "H2O", "CO2", "N2")
-- `isotopologue::String`: Isotopologue identifier (e.g., "1H2-16O", "14N2")
-- `dataset::String`: Dataset name (e.g., "POKAZATEL", "WCCRMT")
-- `force::Bool=false`: Force re-download even if artifact exists
-- `cache_dir::Union{String,Nothing}=nothing`: Optional custom cache directory
+- `molecule`: Molecular formula (e.g. `"H2O"`).
+- `isotopologue`: Isotopologue identifier as used by ExoMol (e.g. `"1H2-16O"`).
+- `dataset`: Dataset label (e.g. `"POKAZATEL"`).
+- `force::Bool=false`: Re-download the dataset even if it already exists in the
+  artifact cache.
+- `verbose::Bool=false`: Forward verbose output to `Downloads.download`.
 
 # Returns
-- `String`: Path to the downloaded dataset definition file
+- `String`: Path to the local artifact directory that contains the dataset
+  definition and accompanying data files.
 
-# Examples
-```julia
-# Download N2 WCCRMT dataset
-dataset_path = download_exomol_dataset("N2", "14N2", "WCCRMT")
-
-# Download H2O POKAZATEL dataset with force reload
-dataset_path = download_exomol_dataset("H2O", "1H2-16O", "POKAZATEL", force=true)
-```
-
-# Notes
-Downloads the JSON format dataset definition file, which contains metadata, and 
-the actual spectroscopic data files (.states, .trans, etc.).
+The returned directory contains at least the `.def.json`, `.states.bz2` and
+`.trans.bz2` files required to load the dataset into Julia using
+[`load_isotopologue`](@ref).
 """
 function get_exomol_dataset(molecule, isotopologue, dataset;
   force=false,verbose=false)

--- a/src/isotopologue.jl
+++ b/src/isotopologue.jl
@@ -1,12 +1,34 @@
 using CodecBzip2
 
 
+"""
+    Isotopologue(definitions, states, transitions)
+
+Composite type holding all data associated with an ExoMol isotopologue.
+
+# Fields
+- `definitions::Dict`: Dataset definition metadata.
+- `states::Vector`: Parsed molecular states (typically `NamedTuple`s).
+- `transitions::Vector{Transition}`: Transition catalogue.
+"""
 struct Isotopologue{S}
   definitions::Dict
   states::Vector{S}
   transitions::Vector{Transition}
 end
 
+"""
+    load_isotopologue(folder)
+
+Load an isotopologue from a directory containing ExoMol dataset files.
+
+# Arguments
+- `folder::AbstractString`: Directory holding `.def.json`, `.states*` and
+  `.trans*` files belonging to an ExoMol dataset.
+
+# Returns
+- `Isotopologue`: Parsed isotopologue data ready for analysis.
+"""
 function load_isotopologue(folder)
 
   files = joinpath.(folder, readdir(folder))
@@ -36,6 +58,20 @@ function load_isotopologue(folder)
   return Isotopologue(def, states, transitions)
 end
 
+"""
+    load_isotopologue(molecule, isotopologue, dataset)
+
+Convenience method that downloads an ExoMol dataset (if necessary) and loads it
+into an [`Isotopologue`](@ref) struct.
+
+# Arguments
+- `molecule`: Molecular formula (e.g. `"H2O"`).
+- `isotopologue`: ExoMol isotopologue identifier.
+- `dataset`: Dataset label.
+
+# Returns
+- `Isotopologue`: Parsed isotopologue data ready for analysis.
+"""
 function load_isotopologue(molecule, isotopologue, dataset)
   ds = ExoMol.get_exomol_dataset(molecule, isotopologue, dataset)
   load_isotopologue(ds)

--- a/src/states.jl
+++ b/src/states.jl
@@ -14,6 +14,20 @@ end
 
 _parse_field(type, value) = type <: AbstractString ? value : parse(type, value)
 
+"""
+    read_state_file(filename[, def])
+
+Read an ExoMol `.states` file and return the parsed state records.
+
+# Arguments
+- `filename::AbstractString`: Path to a `.states` or `.states.bz2` file.
+- `def`: Optional dataset definition as returned by [`read_def_file`](@ref).
+  When omitted the function looks for a sibling `.def.json` file.
+
+# Returns
+- `Vector{NamedTuple}`: State records with field names and types inferred from
+  the dataset definition.
+"""
 function read_state_file(filename, def=read_def_file(replace(filename, r".states(.bz2)" => ".def.json")))
 
   states_def = def["dataset"]["states"]

--- a/src/transitions.jl
+++ b/src/transitions.jl
@@ -1,5 +1,16 @@
 using CodecBzip2
 
+"""
+    Transition(upper_id, lower_id, A, wavenumber)
+
+Container holding a single transition from an ExoMol `.trans` file.
+
+# Fields
+- `upper_id::Int`: Identifier of the upper energy level.
+- `lower_id::Int`: Identifier of the lower energy level.
+- `A::Float64`: Einstein A coefficient (s⁻¹).
+- `wavenumber::Float64`: Transition wavenumber (cm⁻¹).
+"""
 struct Transition
   upper_id::Int
   lower_id::Int
@@ -7,6 +18,17 @@ struct Transition
   wavenumber::Float64
 end
 
+"""
+    read_trans_file(filename)
+
+Read an ExoMol `.trans` file and return the transitions contained in it.
+
+# Arguments
+- `filename::AbstractString`: Path to a `.trans` or `.trans.bz2` file.
+
+# Returns
+- `Vector{Transition}`: Parsed transition records.
+"""
 function read_trans_file(filename)
 
   transitions = Vector{Transition}()


### PR DESCRIPTION
## Summary
- document the public API, including download helpers and the isotopologue container
- expand the README with installation instructions and a quick start example
- enhance the Documenter landing page with an overview and guided usage snippet

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: dataset downloads return HTTP 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c0807b40832f86430bf815479504